### PR TITLE
Fix bulk update mode with sequential snapshots

### DIFF
--- a/WoofWare.Expect/Builder.fs
+++ b/WoofWare.Expect/Builder.fs
@@ -600,7 +600,7 @@ type ExpectBuilder (mode : Mode) =
             match mode, GlobalBuilderConfig.isBulkUpdateMode () with
             | Mode.Update, _ ->
                 failwith
-                    "Snapshot assertion passed, but we are in snapshot-updating mode. Use the `expect` builder instead of `expect'` to assert the contents of a single snapshot; disable `GlobalBuilderConfig.bulkUpdate` to move back to assertion-checking mode."
+                    "Snapshot assertion passed, but we are in snapshot-updating mode. Use the `expect` builder instead of `expect'` to assert the contents of a single snapshot; don't call `GlobalBuilderConfig.enterBulkUpdateMode` to move back to assertion-checking mode."
             | _, true ->
                 // In bulk update mode, register passing tests instead of failing immediately
                 // This allows tests with multiple snapshots to continue processing
@@ -651,7 +651,7 @@ type ExpectBuilder (mode : Mode) =
             match mode, GlobalBuilderConfig.isBulkUpdateMode () with
             | Mode.Update, _ ->
                 failwith
-                    "Snapshot assertion passed, but we are in snapshot-updating mode. Use the `expect` builder instead of `expect'` to assert the contents of a single snapshot; disable `GlobalBuilderConfig.bulkUpdate` to move back to assertion-checking mode."
+                    "Snapshot assertion passed, but we are in snapshot-updating mode. Use the `expect` builder instead of `expect'` to assert the contents of a single snapshot; don't call `GlobalBuilderConfig.enterBulkUpdateMode` to move back to assertion-checking mode."
             | _, true ->
                 // In bulk update mode, register passing tests instead of failing immediately
                 // This allows tests with multiple snapshots to continue processing

--- a/WoofWare.Expect/Builder.fs
+++ b/WoofWare.Expect/Builder.fs
@@ -600,7 +600,7 @@ type ExpectBuilder (mode : Mode) =
             match mode, GlobalBuilderConfig.isBulkUpdateMode () with
             | Mode.Update, _ ->
                 failwith
-                    "Snapshot assertion passed, but we are in snapshot-updating mode. Use the `expect` builder instead of `expect'` to assert the contents of a single snapshot; don't call `GlobalBuilderConfig.enterBulkUpdateMode` to move back to assertion-checking mode."
+                    "Snapshot assertion passed, but we are in snapshot-updating mode. Use the `expect` builder instead of `expect'` to assert the contents of a single snapshot."
             | _, true ->
                 // In bulk update mode, register passing tests instead of failing immediately
                 // This allows tests with multiple snapshots to continue processing
@@ -651,7 +651,7 @@ type ExpectBuilder (mode : Mode) =
             match mode, GlobalBuilderConfig.isBulkUpdateMode () with
             | Mode.Update, _ ->
                 failwith
-                    "Snapshot assertion passed, but we are in snapshot-updating mode. Use the `expect` builder instead of `expect'` to assert the contents of a single snapshot; don't call `GlobalBuilderConfig.enterBulkUpdateMode` to move back to assertion-checking mode."
+                    "Snapshot assertion passed, but we are in snapshot-updating mode. Use the `expect` builder instead of `expect'` to assert the contents of a single snapshot."
             | _, true ->
                 // In bulk update mode, register passing tests instead of failing immediately
                 // This allows tests with multiple snapshots to continue processing

--- a/WoofWare.Expect/Builder.fs
+++ b/WoofWare.Expect/Builder.fs
@@ -598,10 +598,13 @@ type ExpectBuilder (mode : Mode) =
         match CompletedListSnapshotGeneric.passesAssertion state with
         | None ->
             match mode, GlobalBuilderConfig.isBulkUpdateMode () with
-            | Mode.Update, _
-            | _, true ->
+            | Mode.Update, _ ->
                 failwith
                     "Snapshot assertion passed, but we are in snapshot-updating mode. Use the `expect` builder instead of `expect'` to assert the contents of a single snapshot; disable `GlobalBuilderConfig.bulkUpdate` to move back to assertion-checking mode."
+            | _, true ->
+                // In bulk update mode, register passing tests instead of failing immediately
+                // This allows tests with multiple snapshots to continue processing
+                GlobalBuilderConfig.registerPassingTest state.Caller
             | _ -> ()
         | Some (expected, actual) -> raiseError expected actual
 
@@ -646,10 +649,13 @@ type ExpectBuilder (mode : Mode) =
         match CompletedSnapshotGeneric.passesAssertion state with
         | None ->
             match mode, GlobalBuilderConfig.isBulkUpdateMode () with
-            | Mode.Update, _
-            | _, true ->
+            | Mode.Update, _ ->
                 failwith
                     "Snapshot assertion passed, but we are in snapshot-updating mode. Use the `expect` builder instead of `expect'` to assert the contents of a single snapshot; disable `GlobalBuilderConfig.bulkUpdate` to move back to assertion-checking mode."
+            | _, true ->
+                // In bulk update mode, register passing tests instead of failing immediately
+                // This allows tests with multiple snapshots to continue processing
+                GlobalBuilderConfig.registerPassingTest state.Caller
             | _ -> ()
         | Some (expected, actual) -> raiseError expected actual
 

--- a/WoofWare.Expect/Config.fs
+++ b/WoofWare.Expect/Config.fs
@@ -77,7 +77,7 @@ module GlobalBuilderConfig =
                     // Check if we only had passing tests in bulk update mode - this should be an error
                     if allTests.Length = 0 && passingTestsArray.Length > 0 then
                         failwith
-                            "Snapshot assertion passed, but we are in snapshot-updating mode. Use the `expect` builder instead of `expect'` to assert the contents of a single snapshot; disable `GlobalBuilderConfig.bulkUpdate` to move back to assertion-checking mode."
+                            "Snapshot assertion passed, but we are in snapshot-updating mode. Use the `expect` builder instead of `expect'` to assert the contents of a single snapshot; don't call `GlobalBuilderConfig.enterBulkUpdateMode` to move back to assertion-checking mode."
 
                     SnapshotUpdate.updateAll allTests
                 finally

--- a/WoofWare.Expect/Config.fs
+++ b/WoofWare.Expect/Config.fs
@@ -12,6 +12,8 @@ module GlobalBuilderConfig =
 
     let private allTests : ResizeArray<CompletedSnapshot> = ResizeArray ()
 
+    let private passingTests : ResizeArray<CallerInfo> = ResizeArray ()
+
     let internal isBulkUpdateMode () : bool =
         lock locker (fun () -> bulkUpdate.Value > 0)
 
@@ -41,10 +43,19 @@ module GlobalBuilderConfig =
     /// You probably don't need to do this, because your test runner is probably tearing down
     /// anyway after the tests have failed; this is mainly here for WoofWare.Expect's own internal testing.
     /// </remarks>
-    let clearTests () = lock locker allTests.Clear
+    let clearTests () =
+        lock
+            locker
+            (fun () ->
+                allTests.Clear ()
+                passingTests.Clear ()
+            )
 
     let internal registerTest (toAdd : CompletedSnapshot) : unit =
         lock locker (fun () -> allTests.Add toAdd)
+
+    let internal registerPassingTest (caller : CallerInfo) : unit =
+        lock locker (fun () -> passingTests.Add caller)
 
     /// <summary>
     /// For all tests whose failures have already been registered,
@@ -60,8 +71,14 @@ module GlobalBuilderConfig =
             locker
             (fun () ->
                 let allTests = Seq.toArray allTests
+                let passingTestsArray = Seq.toArray passingTests
 
                 try
+                    // Check if we only had passing tests in bulk update mode - this should be an error
+                    if allTests.Length = 0 && passingTestsArray.Length > 0 then
+                        failwith
+                            "Snapshot assertion passed, but we are in snapshot-updating mode. Use the `expect` builder instead of `expect'` to assert the contents of a single snapshot; disable `GlobalBuilderConfig.bulkUpdate` to move back to assertion-checking mode."
+
                     SnapshotUpdate.updateAll allTests
                 finally
                     // double acquiring of reentrant lock is OK, we're not switching threads

--- a/WoofWare.Expect/Config.fs
+++ b/WoofWare.Expect/Config.fs
@@ -36,7 +36,7 @@ module GlobalBuilderConfig =
             )
 
     /// <summary>
-    /// Clear the set of failing tests registered by any previous bulk-update runs.
+    /// Clear the set of failing and passing tests registered by any previous bulk-update runs.
     /// </summary>
     ///
     /// <remarks>
@@ -77,7 +77,7 @@ module GlobalBuilderConfig =
                     // Check if we only had passing tests in bulk update mode - this should be an error
                     if allTests.Length = 0 && passingTestsArray.Length > 0 then
                         failwith
-                            "Snapshot assertion passed, but we are in snapshot-updating mode. Use the `expect` builder instead of `expect'` to assert the contents of a single snapshot; don't call `GlobalBuilderConfig.enterBulkUpdateMode` to move back to assertion-checking mode."
+                            "All snapshot assertions passed, but bulk-update mode was enabled. Disable bulk-update mode by not calling `GlobalBuilderConfig.enterBulkUpdateMode` to return to normal assertion-checking mode."
 
                     SnapshotUpdate.updateAll allTests
                 finally


### PR DESCRIPTION
Previously, when a test method contained multiple expect blocks in bulk update mode, if an earlier snapshot passed, the test would immediately fail with "snapshot matched, but we are in updating mode" and prevent later snapshots from being processed for update.

This change implements deferred validation:
- Passing snapshots in bulk mode are registered instead of failing immediately
- Tests continue execution to process all snapshots
- Validation is deferred until bulk update completion
- Only fails if ALL snapshots passed (no updates needed)

Fixes the issue where tests with mixed passing/failing snapshots couldn't be bulk updated.

🤖 Generated with [Claude Code](https://claude.ai/code)